### PR TITLE
Add functions for Disabling Extensions

### DIFF
--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -96,7 +96,7 @@ trait ExtentionsTrait
 
         $extensions  = (object) $extensionsResult->data;
 
-        foreach($extensions  as $index => $component) {
+        foreach ($extensions  as $index => $component) {
             foreach ($component as $key => $value) {
                 if ($disabled === true) {
                     $extensions ->$index->$key->active = false;

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -51,37 +51,7 @@ trait ExtentionsTrait
             $this->withToken($token);
         }
 
-        $data = [
-            "panel" => [
-                "1" => [
-                    "active" => false
-                ],
-                "2" => [
-                    "active" => false
-                ],
-                "3" => [
-                    "active" => false
-                ]
-            ],
-            "overlay" => [
-                "1" => [
-                    "active" => false
-                ]
-            ],
-            "component" => [
-                "1" => [
-                    "active" => false
-                ],
-                "2" => [
-                    "active" => false
-                ],
-                "3" => [
-                    "active" => false
-                ]
-            ]
-        ];
-
-        return $this->json('users/extensions', $data);
+        return $this->UpdateUserExtensions(null, null, true);
     }
 
     /**
@@ -94,7 +64,7 @@ trait ExtentionsTrait
      */
     public function DisableUserExtensionById (string $token = null, string $parameter = null) : Result
     {
-        return $this->UpdateUserExtensions("id", $parameter);
+        return $this->UpdateUserExtensions("id", $parameter, false);
     }
 
     /**
@@ -107,7 +77,7 @@ trait ExtentionsTrait
      */
     public function DisableUserExtensionByName (string $token = null, string $parameter = null) : Result
     {
-        return $this->UpdateUserExtensions("name", $parameter);
+        return $this->UpdateUserExtensions("name", $parameter, false);
     }
 
     /**
@@ -115,10 +85,11 @@ trait ExtentionsTrait
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
      * @param  string $method    method that will be used to disable extensions
      * @param  string $parameter Parameter that will be used to disable Extensions
+     * @param  bool   $disabled  bool if the set value should be false
      * @return Result Result object
      * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
      */
-    public function UpdateUserExtensions (string $method = null, string $parameter = null) : Result
+    public function UpdateUserExtensions (string $method = null, string $parameter = null, bool $disabled = false) : Result
     {
         $apiresult = $this->getAuthedUserActiveExtensions();
 
@@ -134,55 +105,69 @@ trait ExtentionsTrait
         $overlays = $extentions['overlay'];
         $components = $extentions['component'];
 
-        $data = [
+        $data = (object) [
             "panel" => $panels,
             "overlay" => $overlays,
             "component" => $components
         ];
 
         $i = 1;
-        foreach ($data['panel'] as $key => $value) {
-            if (array_key_exists($method, $value) === true) {
-                if ($value->$method == $parameter) {
-                    $data['panel']->$i->active = false;
-                } else {
-                    $data['panel']->$i->active = $value->active;
-                }
+        foreach ($data->panel as $key => $value) {
+            if ($disabled === true) {
+                $data->panel->$i->active = false;
             } else {
-                $data['panel']->$i = $value;
+                if (isset($value->$method)) {
+                    if ($value->$method <=> $parameter) {
+                        $data->panel->$i->active = false;
+                    } else {
+                        $data->panel->$i->active = $value->active;
+                    }
+                } else {
+                    $data->panel->$i = $value;
+                }
             }
             $i++;
         }
 
         $i = 1;
-        foreach ($data['overlay'] as $key => $value) {
-            if (array_key_exists($method, $value) === true) {
-                if ($value->$method == $parameter) {
-                    $data['overlay']->$i->active = false;
-                } else {
-                    $data['overlay']->$i->active = $value->active;
-                }
+        foreach ($data->overlay as $key => $value) {
+            if ($disabled === true) {
+                $data->overlay->$i->active = false;
             } else {
-                $data['overlay']->$i = $value;
+                if (isset($value->$method)) {
+                    if ($value->$method <=> $parameter) {
+                        $data->overlay->$i->active = false;
+                    } else {
+                        $data->overlay->$i->active = $value->active;
+                    }
+                } else {
+                    $data->overlay->$i = $value;
+                }
             }
             $i++;
         }
 
         $i = 1;
-        foreach ($data['component'] as $key => $value) {
-            if (array_key_exists($method, $value) === true) {
-                if ($value->$method == $parameter) {
-                    $data['component']->$i->active = false;
-                } else {
-                    $data['component']->$i->active = $value->active;
-                }
+        foreach ($data->component as $key => $value) {
+            if ($disabled === true) {
+                $data->component->$i->active = false;
             } else {
-                $data['component']->$i = $value;
+                if (isset($value->$method)) {
+                    if ($value->$method <=> $parameter) {
+                        $data->component->$i->active = false;
+                    } else {
+                        $data->component->$i->active = $value->active;
+                    }
+                } else {
+                    $data->component->$i = $value;
+                }
             }
             $i++;
         }
 
-        return $this->json('users/extensions', $data);
+        $parameter = (array) $data;
+
+        return $this->json('users/extensions', $parameter);
     }
 
     abstract public function get(string $path = '', array $parameters = [], Paginator $paginator = null);

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -19,7 +19,7 @@ trait ExtentionsTrait
         if ($token !== null) {
             $this->withToken($token);
         }
-        return $this->get('users/extensions/list', [], null);
+        return $this->get('users/extensions/list');
     }
 
     /**
@@ -35,7 +35,7 @@ trait ExtentionsTrait
             $this->withToken($token);
         }
 
-        return $this->get('users/extensions', [], null);
+        return $this->get('users/extensions');
     }
 
     /**

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -98,7 +98,9 @@ trait ExtentionsTrait
 
 <<<<<<< HEAD
         foreach($extensions  as $index => $component) {
+
             foreach ($component as $key => $value) {
+<<<<<<< HEAD
 =======
         $data = (object) [
             'panel' => $extensions['panel'],
@@ -113,6 +115,9 @@ trait ExtentionsTrait
             foreach ($data->$type as $key => $value) {
 
 >>>>>>> parent of 08c61dd... Update the updateUserExtensions() function
+=======
+
+>>>>>>> parent of 0f33f4a... Remove Spaces
                 if ($disabled === true) {
 
                     $data->$type->$i->active = false;

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -96,7 +96,7 @@ trait ExtentionsTrait
 
         $extensions  = (object) $extensionsResult->data;
 
-        foreach ($extensions  as $index => $component) {
+        foreach($extensions  as $index => $component) {
             foreach ($component as $key => $value) {
                 if ($disabled === true) {
                     $extensions ->$index->$key->active = false;

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -94,27 +94,53 @@ trait ExtentionsTrait
     {
         $extensionsResult = $this->getAuthedUserActiveExtensions();
 
-        $extensions  = (object) $extensionsResult->data;
+        $extensions = (array) $extensionsResult->data;
 
+<<<<<<< HEAD
         foreach($extensions  as $index => $component) {
             foreach ($component as $key => $value) {
+=======
+        $data = (object) [
+            'panel' => $extensions['panel'],
+            'overlay' => $extensions['overlay'],
+            'component' => $extensions['component'],
+        ];
+
+        $processType = function (string $type) use (&$data, $method, $parameter, $disabled) {
+
+            $i = 1;
+
+            foreach ($data->$type as $key => $value) {
+
+>>>>>>> parent of 08c61dd... Update the updateUserExtensions() function
                 if ($disabled === true) {
-                    $extensions ->$index->$key->active = false;
+
+                    $data->$type->$i->active = false;
+
                 } else {
+
                     if (isset($value->$method)) {
-                        if ($value->$method === $parameter) {
-                            $extensions->$index->$key->active = false;
+
+                        if ($value->$method <=> $parameter) {
+                            $data->$type->$i->active = false;
                         } else {
-                            $extensions->$index->$key->active = $value->active;
+                            $data->$type->$i->active = $value->active;
                         }
+
                     } else {
-                        $extensions->$index->$key = $value;
+                        $data->$type->$i = $value;
                     }
                 }
-            }
-        }
 
-        return $this->json('PUT', 'users/extensions', (array) $extensions);
+                $i++;
+            }
+        };
+
+        $processType('panel');
+        $processType('overlay');
+        $processType('component');
+
+        return $this->json('PUT', 'users/extensions', (array) $data);
     }
 
     abstract public function get(string $path = '', array $parameters = [], Paginator $paginator = null);

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -64,7 +64,7 @@ trait ExtentionsTrait
      */
     public function disableUserExtensionById(string $token = null, string $parameter = null): Result
     {
-        return $this->updateUserExtensions("id", $parameter, false);
+        return $this->updateUserExtensions('id', $parameter, false);
     }
 
     /**
@@ -77,7 +77,7 @@ trait ExtentionsTrait
      */
     public function disableUserExtensionByName(string $token = null, string $parameter = null): Result
     {
-        return $this->updateUserExtensions("name", $parameter, false);
+        return $this->updateUserExtensions('name', $parameter, false);
     }
 
     /**
@@ -134,14 +134,12 @@ trait ExtentionsTrait
         $processType('overlay');
         $processType('component');
 
-        $parameter = (array) $data;
-
-        return $this->json('users/extensions', $parameter);
+        return $this->json('PUT', 'users/extensions', (array) $data);
     }
 
     abstract public function get(string $path = '', array $parameters = [], Paginator $paginator = null);
 
-    abstract public function json(string $path = '', array $parameters = []);
+    abstract public function json(string $method, string $path = '', array $body = null);
 
     abstract public function withToken(string $token);
 }

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -96,12 +96,6 @@ trait ExtentionsTrait
 
         $extensions = (array) $extensionsResult->data;
 
-<<<<<<< HEAD
-        foreach($extensions  as $index => $component) {
-
-            foreach ($component as $key => $value) {
-<<<<<<< HEAD
-=======
         $data = (object) [
             'panel' => $extensions['panel'],
             'overlay' => $extensions['overlay'],
@@ -114,10 +108,6 @@ trait ExtentionsTrait
 
             foreach ($data->$type as $key => $value) {
 
->>>>>>> parent of 08c61dd... Update the updateUserExtensions() function
-=======
-
->>>>>>> parent of 0f33f4a... Remove Spaces
                 if ($disabled === true) {
 
                     $data->$type->$i->active = false;

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -101,7 +101,7 @@ trait ExtentionsTrait
             'component' => $extensions['component'],
         ];
 
-        $processType = function (string $type) use (&$data) {
+        $processType = function (string $type) use (&$data, $method, $parameter, $disabled) {
 
             $i = 1;
 

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -95,69 +95,44 @@ trait ExtentionsTrait
 
         $extensions = (array) $extensionsResult->data;
 
-        $panels = $extensions['panel'];
-        $overlays = $extensions['overlay'];
-        $components = $extensions['component'];
-
         $data = (object) [
-            'panel' => $panels,
-            'overlay' => $overlays,
-            'component' => $components,
+            'panel' => $extensions['panel'],
+            'overlay' => $extensions['overlay'],
+            'component' => $extensions['component'],
         ];
 
-        $i = 1;
-        foreach ($data->panel as $key => $value) {
-            if ($disabled === true) {
-                $data->panel->$i->active = false;
-            } else {
-                if (isset($value->$method)) {
-                    if ($value->$method <=> $parameter) {
-                        $data->panel->$i->active = false;
-                    } else {
-                        $data->panel->$i->active = $value->active;
-                    }
-                } else {
-                    $data->panel->$i = $value;
-                }
-            }
-            $i++;
-        }
+        $processType = function (string $type) use (&$data) {
 
-        $i = 1;
-        foreach ($data->overlay as $key => $value) {
-            if ($disabled === true) {
-                $data->overlay->$i->active = false;
-            } else {
-                if (isset($value->$method)) {
-                    if ($value->$method <=> $parameter) {
-                        $data->overlay->$i->active = false;
-                    } else {
-                        $data->overlay->$i->active = $value->active;
-                    }
-                } else {
-                    $data->overlay->$i = $value;
-                }
-            }
-            $i++;
-        }
+            $i = 1;
 
-        $i = 1;
-        foreach ($data->component as $key => $value) {
-            if ($disabled === true) {
-                $data->component->$i->active = false;
-            } else {
-                if (isset($value->$method)) {
-                    if ($value->$method <=> $parameter) {
-                        $data->component->$i->active = false;
-                    } else {
-                        $data->component->$i->active = $value->active;
-                    }
+            foreach ($data->$type as $key => $value) {
+
+                if ($disabled === true) {
+
+                    $data->$type->$i->active = false;
+
                 } else {
-                    $data->component->$i = $value;
+
+                    if (isset($value->$method)) {
+
+                        if ($value->$method <=> $parameter) {
+                            $data->$type->$i->active = false;
+                        } else {
+                            $data->$type->$i->active = $value->active;
+                        }
+
+                    } else {
+                        $data->$type->$i = $value;
+                    }
                 }
+
+                $i++;
             }
-            $i++;
-        }
+        };
+
+        $processType('panel');
+        $processType('overlay');
+        $processType('component');
 
         $parameter = (array) $data;
 

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -8,7 +8,7 @@ use romanzipp\Twitch\Result;
 trait ExtentionsTrait
 {
     /**
-     * Get currently authed user's extenions with Bearer Token
+     * Get currently authed user's extensions with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
      * @param  string $token Twitch OAuth Token
      * @return Result Result object
@@ -23,7 +23,7 @@ trait ExtentionsTrait
     }
 
     /**
-     * Get currently authed user's active extenions with Bearer Token
+     * Get currently authed user's active extensions with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
      * @param  string $token Twitch OAuth Token
      * @return Result Result object
@@ -38,7 +38,156 @@ trait ExtentionsTrait
         return $this->get('users/extensions', [], null);
     }
 
+    /**
+     * Disable all Extensions of the currently authed user's active extensions with Bearer Token
+     * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
+     * @param  string $token Twitch OAuth Token
+     * @return Result Result object
+     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     */
+    public function DisableAllExtensions(string $token = null): Result
+    {
+        if ($token !== null) {
+            $this->withToken($token);
+        }
+
+        $data = [
+            "panel" => [
+                "1" => [
+                    "active" => false
+                ],
+                "2" => [
+                    "active" => false
+                ],
+                "3" => [
+                    "active" => false
+                ]
+            ],
+            "overlay" => [
+                "1" => [
+                    "active" => false
+                ]
+            ],
+            "component" => [
+                "1" => [
+                    "active" => false
+                ],
+                "2" => [
+                    "active" => false
+                ],
+                "3" => [
+                    "active" => false
+                ]
+            ]
+        ];
+
+        return $this->json('users/extensions', $data);
+    }
+
+    /**
+     * Disables all Extensions of the currently authed user's active extensions, that have the given id with Bearer Token
+     * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
+     * @param  string $token Twitch OAuth Token
+     * @param  string $parameter Id of the Extension that should be deactivated
+     * @return Result Result object
+     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     */
+    public function DisableUserExtensionById (string $token = null, string $parameter = null) : Result
+    {
+        return $this->UpdateUserExtensions("id", $parameter);
+    }
+
+    /**
+     * Disables all Extensions of the currently authed user's active extensions, that have the given Name with Bearer Token
+     * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
+     * @param  string $token Twitch OAuth Token
+     * @param  string $parameter Name of the Extension that should be deactivated
+     * @return Result Result object
+     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     */
+    public function DisableUserExtensionByName (string $token = null, string $parameter = null) : Result
+    {
+        return $this->UpdateUserExtensions("name", $parameter);
+    }
+
+    /**
+     * Disables all Extensions of the currently authed user's active extensions, that have the given method and parameter with Bearer Token
+     * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
+     * @param  string $method    method that will be used to disable extensions
+     * @param  string $parameter Parameter that will be used to disable Extensions
+     * @return Result Result object
+     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     */
+    public function UpdateUserExtensions (string $method = null, string $parameter = null) : Result
+    {
+        $apiresult = $this->getAuthedUserActiveExtensions();
+
+        $extentions = (array) $apiresult->data;
+
+        $data = (object) [
+            "panel" => new \stdClass(),
+            "overlay" => new \stdClass(),
+            "component" => new \stdClass()
+        ];
+
+        $panels = $extentions['panel'];
+        $overlays = $extentions['overlay'];
+        $components = $extentions['component'];
+
+        $data = [
+            "panel" => $panels,
+            "overlay" => $overlays,
+            "component" => $components
+        ];
+
+        $i = 1;
+        foreach ($data['panel'] as $key => $value) {
+            if (array_key_exists($method, $value) === true) {
+                if ($value->$method == $parameter) {
+                    $data['panel']->$i->active = false;
+                } else {
+                    $data['panel']->$i->active = $value->active;
+                }
+            } else {
+                $data['panel']->$i = $value;
+            }
+            $i++;
+        }
+
+        $i = 1;
+        foreach ($data['overlay'] as $key => $value) {
+            if (array_key_exists($method, $value) === true) {
+                if ($value->$method == $parameter) {
+                    $data['overlay']->$i->active = false;
+                } else {
+                    $data['overlay']->$i->active = $value->active;
+                }
+            } else {
+                $data['overlay']->$i = $value;
+            }
+            $i++;
+        }
+
+        $i = 1;
+        foreach ($data['component'] as $key => $value) {
+            if (array_key_exists($method, $value) === true) {
+                if ($value->$method == $parameter) {
+                    $data['component']->$i->active = false;
+                } else {
+                    $data['component']->$i->active = $value->active;
+                }
+            } else {
+                $data['component']->$i = $value;
+            }
+            $i++;
+        }
+
+        return $this->json('users/extensions', $data);
+    }
+
     abstract public function get(string $path = '', array $parameters = [], Paginator $paginator = null);
+
+    abstract public function json(string $path = '', array $parameters = []);
 
     abstract public function withToken(string $token);
 }

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -62,7 +62,7 @@ trait ExtentionsTrait
      * @return Result Result object
      * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
      */
-    public function DisableUserExtensionById (string $token = null, string $parameter = null) : Result
+    public function DisableUserExtensionById(string $token = null, string $parameter = null) : Result
     {
         return $this->UpdateUserExtensions("id", $parameter, false);
     }
@@ -75,7 +75,7 @@ trait ExtentionsTrait
      * @return Result Result object
      * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
      */
-    public function DisableUserExtensionByName (string $token = null, string $parameter = null) : Result
+    public function DisableUserExtensionByName(string $token = null, string $parameter = null) : Result
     {
         return $this->UpdateUserExtensions("name", $parameter, false);
     }
@@ -89,7 +89,7 @@ trait ExtentionsTrait
      * @return Result Result object
      * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
      */
-    public function UpdateUserExtensions (string $method = null, string $parameter = null, bool $disabled = false) : Result
+    public function UpdateUserExtensions(string $method = null, string $parameter = null, bool $disabled = false) : Result
     {
         $apiresult = $this->getAuthedUserActiveExtensions();
 

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -97,9 +97,7 @@ trait ExtentionsTrait
         $extensions  = (object) $extensionsResult->data;
 
         foreach($extensions  as $index => $component) {
-
             foreach ($component as $key => $value) {
-
                 if ($disabled === true) {
                     $extensions ->$index->$key->active = false;
                 } else {

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -94,48 +94,29 @@ trait ExtentionsTrait
     {
         $extensionsResult = $this->getAuthedUserActiveExtensions();
 
-        $extensions = (array) $extensionsResult->data;
+        $extensions  = (object) $extensionsResult->data;
 
-        $data = (object) [
-            'panel' => $extensions['panel'],
-            'overlay' => $extensions['overlay'],
-            'component' => $extensions['component'],
-        ];
+        foreach($extensions  as $index => $component) {
 
-        $processType = function (string $type) use (&$data, $method, $parameter, $disabled) {
-
-            $i = 1;
-
-            foreach ($data->$type as $key => $value) {
+            foreach ($component as $key => $value) {
 
                 if ($disabled === true) {
-
-                    $data->$type->$i->active = false;
-
+                    $extensions ->$index->$key->active = false;
                 } else {
-
                     if (isset($value->$method)) {
-
-                        if ($value->$method <=> $parameter) {
-                            $data->$type->$i->active = false;
+                        if ($value->$method === $parameter) {
+                            $extensions->$index->$key->active = false;
                         } else {
-                            $data->$type->$i->active = $value->active;
+                            $extensions->$index->$key->active = $value->active;
                         }
-
                     } else {
-                        $data->$type->$i = $value;
+                        $extensions->$index->$key = $value;
                     }
                 }
-
-                $i++;
             }
-        };
+        }
 
-        $processType('panel');
-        $processType('overlay');
-        $processType('component');
-
-        return $this->json('PUT', 'users/extensions', (array) $data);
+        return $this->json('PUT', 'users/extensions', (array) $extensions);
     }
 
     abstract public function get(string $path = '', array $parameters = [], Paginator $paginator = null);

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -19,6 +19,7 @@ trait ExtentionsTrait
         if ($token !== null) {
             $this->withToken($token);
         }
+        
         return $this->get('users/extensions/list');
     }
 

--- a/src/Traits/ExtentionsTrait.php
+++ b/src/Traits/ExtentionsTrait.php
@@ -10,9 +10,9 @@ trait ExtentionsTrait
     /**
      * Get currently authed user's extensions with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $token Twitch OAuth Token
-     * @return Result Result object
-     * @see    "https://dev.twitch.tv/docs/api/reference#get-user-extensions"
+     * @param  string $token    Twitch OAuth Token
+     * @return Result           Result object
+     * @see    https://dev.twitch.tv/docs/api/reference#get-user-extensions
      */
     public function getAuthedUserExtensions(string $token = null): Result
     {
@@ -25,9 +25,9 @@ trait ExtentionsTrait
     /**
      * Get currently authed user's active extensions with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $token Twitch OAuth Token
-     * @return Result Result object
-     * @see    "https://dev.twitch.tv/docs/api/reference#get-user-active-extensions"
+     * @param  string $token    Twitch OAuth Token
+     * @return Result           Result object
+     * @see    https://dev.twitch.tv/docs/api/reference#get-user-active-extensions
      */
     public function getAuthedUserActiveExtensions(string $token = null): Result
     {
@@ -41,74 +41,68 @@ trait ExtentionsTrait
     /**
      * Disable all Extensions of the currently authed user's active extensions with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $token Twitch OAuth Token
-     * @return Result Result object
+     * @param  string $token    Twitch OAuth Token
+     * @return Result           Result object
      * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
      */
-    public function DisableAllExtensions(string $token = null): Result
+    public function disableAllExtensions(string $token = null): Result
     {
         if ($token !== null) {
             $this->withToken($token);
         }
 
-        return $this->UpdateUserExtensions(null, null, true);
+        return $this->updateUserExtensions(null, null, true);
     }
 
     /**
      * Disables all Extensions of the currently authed user's active extensions, that have the given id with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $token Twitch OAuth Token
-     * @param  string $parameter Id of the Extension that should be deactivated
-     * @return Result Result object
-     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     * @param  string $token        Twitch OAuth Token
+     * @param  string $parameter    Id of the Extension that should be deactivated
+     * @return Result               Result object
+     * @see    https://dev.twitch.tv/docs/api/reference/#update-user-extensions
      */
-    public function DisableUserExtensionById(string $token = null, string $parameter = null) : Result
+    public function disableUserExtensionById(string $token = null, string $parameter = null): Result
     {
-        return $this->UpdateUserExtensions("id", $parameter, false);
+        return $this->updateUserExtensions("id", $parameter, false);
     }
 
     /**
      * Disables all Extensions of the currently authed user's active extensions, that have the given Name with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $token Twitch OAuth Token
-     * @param  string $parameter Name of the Extension that should be deactivated
-     * @return Result Result object
-     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     * @param  string $token        Twitch OAuth Token
+     * @param  string $parameter    Name of the Extension that should be deactivated
+     * @return Result               Result object
+     * @see    https://dev.twitch.tv/docs/api/reference/#update-user-extensions
      */
-    public function DisableUserExtensionByName(string $token = null, string $parameter = null) : Result
+    public function disableUserExtensionByName(string $token = null, string $parameter = null): Result
     {
-        return $this->UpdateUserExtensions("name", $parameter, false);
+        return $this->updateUserExtensions("name", $parameter, false);
     }
 
     /**
      * Disables all Extensions of the currently authed user's active extensions, that have the given method and parameter with Bearer Token
      * Note: Bearer OAuth Token and the state "user:edit:broadcast" are both required
-     * @param  string $method    method that will be used to disable extensions
+     * @param  string $method    Method that will be used to disable extensions
      * @param  string $parameter Parameter that will be used to disable Extensions
-     * @param  bool   $disabled  bool if the set value should be false
-     * @return Result Result object
-     * @see    "https://dev.twitch.tv/docs/api/reference/#update-user-extensions"
+     * @param  bool   $disabled  Weather the set value should be false
+     * @return Result            Result object
+     * @see    https://dev.twitch.tv/docs/api/reference/#update-user-extensions
      */
-    public function UpdateUserExtensions(string $method = null, string $parameter = null, bool $disabled = false) : Result
+    public function updateUserExtensions(string $method = null, string $parameter = null, bool $disabled = false): Result
     {
-        $apiresult = $this->getAuthedUserActiveExtensions();
+        $extensionsResult = $this->getAuthedUserActiveExtensions();
 
-        $extentions = (array) $apiresult->data;
+        $extensions = (array) $extensionsResult->data;
 
-        $data = (object) [
-            "panel" => new \stdClass(),
-            "overlay" => new \stdClass(),
-            "component" => new \stdClass()
-        ];
-
-        $panels = $extentions['panel'];
-        $overlays = $extentions['overlay'];
-        $components = $extentions['component'];
+        $panels = $extensions['panel'];
+        $overlays = $extensions['overlay'];
+        $components = $extensions['component'];
 
         $data = (object) [
-            "panel" => $panels,
-            "overlay" => $overlays,
-            "component" => $components
+            'panel' => $panels,
+            'overlay' => $overlays,
+            'component' => $components,
         ];
 
         $i = 1;

--- a/src/Traits/UsersTrait.php
+++ b/src/Traits/UsersTrait.php
@@ -117,5 +117,5 @@ trait UsersTrait
 
     abstract public function put(string $path = '', array $parameters = [], Paginator $paginator = null);
 
-    abstract public function withToken();
+    abstract public function withToken(string $token);
 }

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -254,7 +254,7 @@ class Twitch
 
         $headers = $this->generateHeaders($jsonBody ? true : false);
 
-        $result = $this->executeQuery($method, $uri, $headers, $body);
+        $result = $this->executeQuery($method, $uri, $headers, $jsonBody);
 
         $this->clearOnce();
 

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -38,7 +38,7 @@ class Twitch
 
     use LegacyOAuthTrait;
     use LegacyRootTrait;
-    
+
     const BASE_URI = 'https://api.twitch.tv/helix/';
 
     /**
@@ -46,7 +46,7 @@ class Twitch
      * @var \GuzzleHttp\Client
      */
     protected $client;
-    
+
     /**
      * Paginator object
      * @var Paginator
@@ -100,7 +100,7 @@ class Twitch
             $this->setClientId(config('twitch-api.client_id'));
             $this->setClientSecret(config('twitch-api.client_secret'));
         }
-        
+
         $this->client = new Client([
             'base_uri' => self::BASE_URI,
         ]);
@@ -125,7 +125,7 @@ class Twitch
         if (!$this->clientId) {
             throw new RequestRequiresClientIdException();
         }
-        
+
         return $this->clientId;
     }
 
@@ -173,7 +173,7 @@ class Twitch
 
         return $this;
     }
-    
+
     /**
      * Get Twitch token
      * @return string Twitch token
@@ -258,9 +258,9 @@ class Twitch
 
         try {
             $request = new Request($method, $uri, $headers, $this->legacy ? true : false);
-            
+
             $response = $this->client->send($request);
-            
+
             $result = new Result($response, null, $paginator, $this->legacy ? true : false);
         } catch (RequestException $exception) {
             $result = new Result($exception->getResponse(), $exception, $paginator);
@@ -275,7 +275,7 @@ class Twitch
 
         return $result;
     }
-    
+
     /**
      * Generate URL for API
      * @param  string      $url        Query uri
@@ -287,12 +287,12 @@ class Twitch
     {
         foreach ($parameters as $optionKey => $option) {
             $data = !is_array($option) ? [$option] : $option;
-            
+
             foreach ($data as $key => $value) {
                 $url .= (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . $optionKey . '=' . $value;
             }
         }
-        
+
         return $url;
     }
 
@@ -303,52 +303,52 @@ class Twitch
      * @param  array  $parameters Query parameters
      * @return Result             Result object
      */
-    public function jsonquery(string $method = '', string $path = '', array $parameters = []) : Result
+    public function jsonquery(string $method = '', string $path = '', array $parameters = []): Result
     {
         $uri = self::BASE_URI . $path;
-        
+
         $headers = [
             'Client-ID' => $this->getClientId(),
-            'Content-Type' => 'application/json'
+            'Content-Type' => 'application/json',
         ];
-        
+
         if ($this->token) {
             $headers['Authorization'] = ($this->legacy ? 'OAuth ' : 'Bearer ') . $this->token;
         }
-        
+
         $body = $this->generateBody($parameters);
-    
+
         try {
             $request = new Request($method, $uri, $headers, $body);
-            
+
             $response = $this->client->send($request);
-            
+
             $result = new Result($response, null, null, $this->legacy ? true : false);
         } catch (RequestException $exception) {
             $result = new Result($exception->getResponse(), $exception, null);
         } catch (ClientException $exception) {
             $result = new Result($exception->getResponse(), $exception, null);
         }
-        
+
         $result->request = $request;
         $result->twitch = $this;
-        
+
         $this->clearOnce();
-        
+
         return $result;
     }
-    
+
     /**
      * Generate JsonBody for Request
      * @param  array       $parameters Body parameters
      * @return string                  Encoded json string
      */
-    public function generateBody(array $parameters = null) : string
+    public function generateBody(array $parameters = null): string
     {
         $data = [
-            "data" => $parameters
+            "data" => $parameters,
         ];
-        
+
         return json_encode($data);
     }
 }

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -254,7 +254,7 @@ class Twitch
 
         $headers = $this->generateHeaders($jsonBody ? true : false);
 
-        $result = $this->executeQuery($method, $uri, $headers, $jsonBody);
+        $result = $this->executeQuery($method, $uri, $headers, $paginator, $jsonBody);
 
         $this->clearOnce();
 
@@ -269,7 +269,7 @@ class Twitch
      * @param  mixed  $jsonBody JSON Body
      * @return Result
      */
-    private function executeQuery(string $method, string $uri, array $headers, $jsonBody = null): Result
+    private function executeQuery(string $method, string $uri, array $headers, Paginator $paginator = null, $jsonBody = null): Result
     {
         try {
             $request = new Request($method, $uri, $headers, $jsonBody);

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -277,9 +277,13 @@ class Twitch
             $response = $this->client->send($request);
 
             $result = new Result($response, null, $paginator, $this->legacy ? true : false);
+
         } catch (RequestException $exception) {
+
             $result = new Result($exception->getResponse(), $exception, $paginator);
+
         } catch (ClientException $exception) {
+
             $result = new Result($exception->getResponse(), $exception, $paginator);
         }
 

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -317,7 +317,7 @@ class Twitch
         }
         
         $body = $this->generateBody($parameters);
-        
+    
         try {
             $request = new Request($method, $uri, $headers, $body);
             
@@ -330,7 +330,7 @@ class Twitch
             $result = new Result($exception->getResponse(), $exception, null);
         }
         
-        $result->request = $request;     
+        $result->request = $request;
         $result->twitch = $this;
         
         $this->clearOnce();

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -277,13 +277,9 @@ class Twitch
             $response = $this->client->send($request);
 
             $result = new Result($response, null, $paginator, $this->legacy ? true : false);
-
         } catch (RequestException $exception) {
-
             $result = new Result($exception->getResponse(), $exception, $paginator);
-
         } catch (ClientException $exception) {
-
             $result = new Result($exception->getResponse(), $exception, $paginator);
         }
 


### PR DESCRIPTION
Following up my last pull request I've added functions to update the authed users extensions, unfortunately you can't enable extensions via the api, but your can disable them. I know that this code is messy am i'm sorry for that, but it works (atleast) for now if you want to redo it feel free to do so.

Added

- Querymethod: `json(string $mehtod, string $path, array $parameters)` 
- Function: `generateBody(array $parameters)` this builds the body for the jsonquery.
- Function: `jsonquery(string $method, string $path, array $parameters)` to send requests with json body.

- Function: `DisableAllExtensions(string $token)`  returns `UpdateUserExtensions() with bool $disabled = true `.
- Function `DisableUserExtensionById(string $token, string $parameter)` this parses the $parameter to `UpdateUserExtensions()`.
- Function `DisableUserExtensionByName(string $token, string $parameter)`  this also parses the $parameter to `UpdateUserExtensions()`.
- Function `UpdateUserExtensions(string $method, string $parameter, bool $disabled)` this loops through all of active Extensions of the authed user and disables extensions based on the given $method and $parameters. 

Fixed

- Added missing abstract method parameter in UsersTrait.php that resulted in an error (atleast for me).
- Typos because i'm an idiot.

Removed
- my will to further continue my life because of PHP arrays. (actually nothing was removed)