### PR TITLE
Fix for Webhooks Topics & Add Method to get all active Subscriptions

### DIFF
--- a/src/Traits/WebhooksTrait.php
+++ b/src/Traits/WebhooksTrait.php
@@ -49,12 +49,12 @@ trait WebhooksTrait
 
     public function webhookTopicUserGainsFollower(int $to): string
     {
-        return static::BASE_URI . 'users/follows?first=1&to_id=' . $from;
+        return static::BASE_URI . 'users/follows?first=1&to_id=' . $to;
     }
 
     public function webhookTopicUserFollowsUser(int $from, int $to): string
     {
-        return static::BASE_URI . 'users/follows?first=1&from_id=' . $from . '&to_id' . $from;
+        return static::BASE_URI . 'users/follows?first=1&from_id=' . $from . '&to_id' . $to;
     }
 
     abstract public function post(string $path = '', array $parameters = [], Paginator $paginator = null);

--- a/src/Traits/WebhooksTrait.php
+++ b/src/Traits/WebhooksTrait.php
@@ -12,7 +12,7 @@ trait WebhooksTrait
         $attributes = [
             'hub.callback' => $callback,
             'hub.mode' => 'subscribe',
-            'hub.topic' => $topic,
+            'hub.topic' => urlencode($topic),
         ];
 
         if ($lease !== null) {
@@ -31,10 +31,15 @@ trait WebhooksTrait
         $attributes = [
             'hub.callback' => $callback,
             'hub.mode' => 'unsubscribe',
-            'hub.topic' => $topic,
+            'hub.topic' => urlencode($topic),
         ];
 
         return $this->post('webhooks/hub', $attributes);
+    }
+
+    public function getWebhookSubscriptions(array $parameters = []): Result
+    {
+        return $this->get('webhooks/subscriptions', $parameters);
     }
 
     public function webhookTopicStreamMonitor(int $user): string


### PR DESCRIPTION
## Fix For Webhooks Topics

Some topics contains characters that need to be urlencoded.

## Add New Method For Active Subscriptions

I added the endpoint to list all active subscriptions.

```php
$response = $twitch
  ->withToken("token")
  ->getWebhookSubscriptions();

// returns an array with active subscriptions
dd($response->data);
```