### PR TITLE
Remove unnecessary cache driver

### DIFF
--- a/config/twitch-api.php
+++ b/config/twitch-api.php
@@ -33,11 +33,6 @@ return [
         'cache' => true,
 
         /*
-         * The cache driver to use for storing Client Credentials.
-         */
-        'cache_driver' => null,
-
-        /*
         * The cache store to use for storing Client Credentials.
         */
         'cache_store' => null,

--- a/src/Concerns/AuthenticationTrait.php
+++ b/src/Concerns/AuthenticationTrait.php
@@ -3,6 +3,7 @@
 namespace romanzipp\Twitch\Concerns;
 
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Support\Facades\Cache;
 use romanzipp\Twitch\Enums\GrantType;
 use romanzipp\Twitch\Objects\AccessToken;
 use romanzipp\Twitch\Result;
@@ -110,15 +111,7 @@ trait AuthenticationTrait
      */
     protected function getClientCredentialsCacheRepository(): Repository
     {
-        $cache = cache();
-
-        if ($driver = config('twitch-api.oauth_client_credentials.cache_driver')) {
-            $cache->driver($driver);
-        }
-
-        return $cache->store(
-            config('twitch-api.oauth_client_credentials.cache_store')
-        );
+        return Cache::store(config('twitch-api.oauth_client_credentials.cache_store'));
     }
 
     public function isAuthenticationUri(string $uri): bool


### PR DESCRIPTION
The laravel cache driver calls the same method within the cache manager:

So the cache driver is redundant. To my knowledge it is not a breaking change.

```
/**
 * Get a cache driver instance.
 *
 * @param  string|null  $driver
 * @return \Illuminate\Contracts\Cache\Repository
 */
public function driver($driver = null)
{
    return $this->store($driver);
}
```