### PR TITLE
use strtotime to convert date string to timestamp

### DIFF
--- a/src/Objects/EventSubSignature.php
+++ b/src/Objects/EventSubSignature.php
@@ -9,11 +9,6 @@ use Symfony\Component\HttpFoundation\HeaderBag;
 class EventSubSignature
 {
     /**
-     * Represents the timestamp format of twitch's eventsub api.
-     */
-    const TIMESTAMP_PATTERN = '/^(?<pre>[\d\-:.T]+)\.(?<nano>\d{6,9})Z$/';
-
-    /**
      * Verifies the signature header sent by Twitch. Throws an SignatureVerificationException
      * exception if the verification fails for any reason.
      *
@@ -54,15 +49,11 @@ class EventSubSignature
             return null;
         }
 
-        if ( ! preg_match(self::TIMESTAMP_PATTERN, $rawTimestamp, $matches)) {
-            return null;
+        if (preg_match('/\.[0-9]{9}Z$/', $rawTimestamp)) {
+            $rawTimestamp = substr_replace($rawTimestamp, '', -2, 1);
         }
 
-        $dateTime = DateTime::createFromFormat(
-            'Y-m-d\TH:i:s.u\Z',
-            sprintf('%s.%dZ', $matches['pre'], substr($matches['nano'], 0, 6))
-        );
-
-        return $dateTime->getTimestamp();
+        $timestamp = strtotime($rawTimestamp);
+        return $timestamp ?: null;
     }
 }

--- a/src/Objects/EventSubSignature.php
+++ b/src/Objects/EventSubSignature.php
@@ -49,8 +49,9 @@ class EventSubSignature
             return null;
         }
 
-        if (preg_match('/\.[0-9]{9}Z$/', $rawTimestamp)) {
-            $rawTimestamp = substr_replace($rawTimestamp, '', -2, 1);
+        if (preg_match('/\.([\d]{9,})Z$/', $rawTimestamp, $match)) {
+            $length = strlen($match[1]) - 8;
+            $rawTimestamp = substr_replace($rawTimestamp, '', ($length * -1) - 1, $length);
         }
 
         $timestamp = strtotime($rawTimestamp);


### PR DESCRIPTION
Because I have an issue related to the timestamp in prod (see https://github.com/romanzipp/Laravel-Twitch/issues/87), I decided to use `strtotime` to get the timestamp of the twitch date. It works both with Twitch CLI and in prod.