### PR TITLE
added event message id, retries and timestamp to eventsub events

### DIFF
--- a/src/Events/EventSubHandled.php
+++ b/src/Events/EventSubHandled.php
@@ -2,7 +2,7 @@
 
 namespace romanzipp\Twitch\Events;
 
-use Carbon\CarbonInterface;
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -19,23 +19,23 @@ class EventSubHandled
     public $payload;
 
     /**
-     * The ID for the event provided by Twitch
+     * The ID for the event provided by Twitch.
      *
      * @var string
      */
     public $id;
 
     /**
-     * The number of retries to receive this event
+     * The number of retries to receive this event.
      *
      * @var int
      */
     public $retries;
 
     /**
-     * The timestamp of when the event was sent the first time
+     * The timestamp of when the event was sent the first time.
      *
-     * @var CarbonInterface
+     * @var Carbon
      */
     public $timestamp;
 
@@ -45,9 +45,9 @@ class EventSubHandled
      * @param array $payload
      * @param string $id
      * @param int $retries
-     * @param CarbonInterface $timestamp
+     * @param Carbon $timestamp
      */
-    public function __construct(array $payload, string $id, int $retries, CarbonInterface $timestamp)
+    public function __construct(array $payload, string $id, int $retries, Carbon $timestamp)
     {
         $this->payload = $payload;
         $this->id = $id;

--- a/src/Events/EventSubHandled.php
+++ b/src/Events/EventSubHandled.php
@@ -2,6 +2,7 @@
 
 namespace romanzipp\Twitch\Events;
 
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -18,14 +19,39 @@ class EventSubHandled
     public $payload;
 
     /**
+     * The ID for the event provided by Twitch
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The number of retries to receive this event
+     *
+     * @var int
+     */
+    public $retries;
+
+    /**
+     * The timestamp of when the event was sent the first time
+     *
+     * @var CarbonInterface
+     */
+    public $timestamp;
+
+    /**
      * Create a new event instance.
      *
      * @param array $payload
-     *
-     * @return void
+     * @param string $id
+     * @param int $retries
+     * @param CarbonInterface $timestamp
      */
-    public function __construct(array $payload)
+    public function __construct(array $payload, string $id, int $retries, CarbonInterface $timestamp)
     {
         $this->payload = $payload;
+        $this->id = $id;
+        $this->retries = $retries;
+        $this->timestamp = $timestamp;
     }
 }

--- a/src/Events/EventSubReceived.php
+++ b/src/Events/EventSubReceived.php
@@ -2,6 +2,7 @@
 
 namespace romanzipp\Twitch\Events;
 
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -18,14 +19,39 @@ class EventSubReceived
     public $payload;
 
     /**
+     * The ID for the event provided by Twitch
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The number of retries to receive this event
+     *
+     * @var int
+     */
+    public $retries;
+
+    /**
+     * The timestamp of when the event was sent the first time
+     *
+     * @var CarbonInterface
+     */
+    public $timestamp;
+
+    /**
      * Create a new event instance.
      *
      * @param array $payload
-     *
-     * @return void
+     * @param string $id
+     * @param int $retries
+     * @param CarbonInterface $timestamp
      */
-    public function __construct(array $payload)
+    public function __construct(array $payload, string $id, int $retries, CarbonInterface $timestamp)
     {
         $this->payload = $payload;
+        $this->id = $id;
+        $this->retries = $retries;
+        $this->timestamp = $timestamp;
     }
 }

--- a/src/Events/EventSubReceived.php
+++ b/src/Events/EventSubReceived.php
@@ -2,7 +2,7 @@
 
 namespace romanzipp\Twitch\Events;
 
-use Carbon\CarbonInterface;
+use Carbon\Carbon;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -19,23 +19,23 @@ class EventSubReceived
     public $payload;
 
     /**
-     * The ID for the event provided by Twitch
+     * The ID for the event provided by Twitch.
      *
      * @var string
      */
     public $id;
 
     /**
-     * The number of retries to receive this event
+     * The number of retries to receive this event.
      *
      * @var int
      */
     public $retries;
 
     /**
-     * The timestamp of when the event was sent the first time
+     * The timestamp of when the event was sent the first time.
      *
-     * @var CarbonInterface
+     * @var Carbon
      */
     public $timestamp;
 
@@ -45,9 +45,9 @@ class EventSubReceived
      * @param array $payload
      * @param string $id
      * @param int $retries
-     * @param CarbonInterface $timestamp
+     * @param Carbon $timestamp
      */
-    public function __construct(array $payload, string $id, int $retries, CarbonInterface $timestamp)
+    public function __construct(array $payload, string $id, int $retries, Carbon $timestamp)
     {
         $this->payload = $payload;
         $this->id = $id;

--- a/src/Http/Controllers/EventSubController.php
+++ b/src/Http/Controllers/EventSubController.php
@@ -2,6 +2,7 @@
 
 namespace romanzipp\Twitch\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
@@ -33,8 +34,9 @@ class EventSubController extends Controller
 
         $messageType = $request->header('twitch-eventsub-message-type');
         $messageId = $request->header('twitch-eventsub-message-id');
-        $retries = $request->header('twitch-eventsub-message-retry');
-        $timestamp = EventSubSignature::getTimestamp($request->header('twitch-eventsub-message-timestamp'));
+        $retries = (int) $request->header('twitch-eventsub-message-retry');
+        $timestamp = Carbon::createFromTimestampUTC(
+                        EventSubSignature::getTimestamp($request->header('twitch-eventsub-message-timestamp')));
 
         if ('notification' === $messageType) {
             $messageType = sprintf('%s.notification', $payload['subscription']['type']);

--- a/tests/EventSubControllerTest.php
+++ b/tests/EventSubControllerTest.php
@@ -78,7 +78,7 @@ class EventSubControllerTest extends TestCase
         $request->headers->set('twitch-eventsub-message-type', 'notification');
         $request->headers->set('twitch-eventsub-message-id', Uuid::uuid4());
         $request->headers->set('twitch-eventsub-message-retry', 0);
-        $request->headers->set('twitch-eventsub-message-timestamp', Carbon::now()->toJSON());
+        $request->headers->set('twitch-eventsub-message-timestamp', Carbon::now()->utc()->toIso8601ZuluString());
 
         return $request;
     }

--- a/tests/EventSubControllerTest.php
+++ b/tests/EventSubControllerTest.php
@@ -2,9 +2,11 @@
 
 namespace romanzipp\Twitch\Tests;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Event;
+use Ramsey\Uuid\Uuid;
 use romanzipp\Twitch\Enums\EventSubType;
 use romanzipp\Twitch\Events\EventSubHandled;
 use romanzipp\Twitch\Events\EventSubReceived;
@@ -74,6 +76,9 @@ class EventSubControllerTest extends TestCase
         );
 
         $request->headers->set('twitch-eventsub-message-type', 'notification');
+        $request->headers->set('twitch-eventsub-message-id', Uuid::uuid4());
+        $request->headers->set('twitch-eventsub-message-retry', 0);
+        $request->headers->set('twitch-eventsub-message-timestamp', Carbon::now()->toJSON());
 
         return $request;
     }

--- a/tests/EventSubControllerTest.php
+++ b/tests/EventSubControllerTest.php
@@ -78,7 +78,7 @@ class EventSubControllerTest extends TestCase
         $request->headers->set('twitch-eventsub-message-type', 'notification');
         $request->headers->set('twitch-eventsub-message-id', Uuid::uuid4());
         $request->headers->set('twitch-eventsub-message-retry', 0);
-        $request->headers->set('twitch-eventsub-message-timestamp', Carbon::now()->utc()->toIso8601ZuluString());
+        $request->headers->set('twitch-eventsub-message-timestamp', Carbon::now()->toIso8601ZuluString());
 
         return $request;
     }


### PR DESCRIPTION
I think, adding the event id, number of retries and the timestamp is necessary to check, whether the event should still be handled when for example people try to do a replay attack or Twitch sends events multiple times.

see: https://github.com/romanzipp/Laravel-Twitch/issues/67#issuecomment-829048428