### PR TITLE
APIs and EventSub for Polls and Predictions

### DIFF
--- a/src/Concerns/Api/PollsTrait.php
+++ b/src/Concerns/Api/PollsTrait.php
@@ -12,6 +12,15 @@ trait PollsTrait
     use AbstractOperationsTrait;
     use AbstractValidationTrait;
 
+    /**
+     * Get information about all polls or specific polls for a Twitch channel. Poll information is available for 90 days.
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#get-polls
+     *
+     * @param array $parameters
+     * @param Paginator|null $paginator
+     * @return Result
+     */
     public function getPolls(array $parameters = [], Paginator $paginator = null): Result
     {
         $this->validateRequired($parameters, ['broadcaster_id']);
@@ -19,6 +28,15 @@ trait PollsTrait
         return $this->get('polls', $parameters, $paginator);
     }
 
+    /**
+     * Create a poll for a specific Twitch channel.
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#create-poll
+     *
+     * @param array $parameters
+     * @param array $body
+     * @return Result
+     */
     public function createPolls(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
@@ -31,6 +49,15 @@ trait PollsTrait
         return $this->post('polls', $parameters, null, $body);
     }
 
+    /**
+     * End a poll that is currently active.
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#end-poll
+     *
+     * @param array $parameters
+     * @param array $body
+     * @return Result
+     */
     public function updatePoll(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [

--- a/src/Concerns/Api/PollsTrait.php
+++ b/src/Concerns/Api/PollsTrait.php
@@ -25,11 +25,10 @@ trait PollsTrait
             'broadcaster_id',
             'title',
             'choices',
-            'choice.title',
             'duration',
         ]);
 
-        return $this->post('predictions', $parameters, null, $body);
+        return $this->post('polls', $parameters, null, $body);
     }
 
     public function updatePoll(array $parameters = [], array $body = []): Result
@@ -40,6 +39,6 @@ trait PollsTrait
             'status',
         ]);
 
-        return $this->patch('predictions', $parameters, null, $body);
+        return $this->patch('polls', $parameters, null, $body);
     }
 }

--- a/src/Concerns/Api/PollsTrait.php
+++ b/src/Concerns/Api/PollsTrait.php
@@ -37,7 +37,7 @@ trait PollsTrait
      * @param array $body
      * @return Result
      */
-    public function createPolls(array $parameters = [], array $body = []): Result
+    public function createPoll(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
             'broadcaster_id',
@@ -58,7 +58,7 @@ trait PollsTrait
      * @param array $body
      * @return Result
      */
-    public function updatePoll(array $parameters = [], array $body = []): Result
+    public function endPoll(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
             'broadcaster_id',

--- a/src/Concerns/Api/PollsTrait.php
+++ b/src/Concerns/Api/PollsTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace romanzipp\Twitch\Concerns\Api;
+
+use romanzipp\Twitch\Concerns\Operations\AbstractOperationsTrait;
+use romanzipp\Twitch\Concerns\Operations\AbstractValidationTrait;
+use romanzipp\Twitch\Objects\Paginator;
+use romanzipp\Twitch\Result;
+
+trait PollsTrait
+{
+    use AbstractOperationsTrait;
+    use AbstractValidationTrait;
+
+    public function getPolls(array $parameters = [], Paginator $paginator = null): Result
+    {
+        $this->validateRequired($parameters, ['broadcaster_id']);
+
+        return $this->get('polls', $parameters, $paginator);
+    }
+
+    public function createPolls(array $parameters = [], array $body = []): Result
+    {
+        $this->validateRequired($body, [
+            'broadcaster_id',
+            'title',
+            'choices',
+            'choice.title',
+            'duration',
+        ]);
+
+        return $this->post('predictions', $parameters, null, $body);
+    }
+
+    public function updatePoll(array $parameters = [], array $body = []): Result
+    {
+        $this->validateRequired($body, [
+            'broadcaster_id',
+            'id',
+            'status',
+        ]);
+
+        return $this->patch('predictions', $parameters, null, $body);
+    }
+}

--- a/src/Concerns/Api/PredictionsTrait.php
+++ b/src/Concerns/Api/PredictionsTrait.php
@@ -12,6 +12,15 @@ trait PredictionsTrait
     use AbstractOperationsTrait;
     use AbstractValidationTrait;
 
+    /**
+     * Get information about all Channel Points Predictions or specific Channel Points Predictions for a Twitch channel.
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#get-predictions
+     *
+     * @param array $parameters
+     * @param Paginator|null $paginator
+     * @return Result
+     */
     public function getPredictions(array $parameters = [], Paginator $paginator = null): Result
     {
         $this->validateRequired($parameters, ['broadcaster_id']);
@@ -19,6 +28,15 @@ trait PredictionsTrait
         return $this->get('predictions', $parameters, $paginator);
     }
 
+    /**
+     * Create a Channel Points Prediction for a specific Twitch channel.
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#create-prediction
+     *
+     * @param array $parameters
+     * @param array $body
+     * @return Result
+     */
     public function createPredictions(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
@@ -31,6 +49,17 @@ trait PredictionsTrait
         return $this->post('predictions', $parameters, null, $body);
     }
 
+    /**
+     * Lock, resolve, or cancel a Channel Points Prediction.
+     * Active Predictions can be updated to be “locked,” “resolved,” or “canceled.”
+     * Locked Predictions can be updated to be “resolved” or “canceled.”
+     *
+     * @see https://dev.twitch.tv/docs/api/reference#end-prediction
+     *
+     * @param array $parameters
+     * @param array $body
+     * @return Result
+     */
     public function updatePrediction(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [

--- a/src/Concerns/Api/PredictionsTrait.php
+++ b/src/Concerns/Api/PredictionsTrait.php
@@ -25,7 +25,6 @@ trait PredictionsTrait
             'broadcaster_id',
             'title',
             'outcomes',
-            'outcome.title',
             'prediction_window',
         ]);
 

--- a/src/Concerns/Api/PredictionsTrait.php
+++ b/src/Concerns/Api/PredictionsTrait.php
@@ -37,7 +37,7 @@ trait PredictionsTrait
      * @param array $body
      * @return Result
      */
-    public function createPredictions(array $parameters = [], array $body = []): Result
+    public function createPrediction(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
             'broadcaster_id',
@@ -60,7 +60,7 @@ trait PredictionsTrait
      * @param array $body
      * @return Result
      */
-    public function updatePrediction(array $parameters = [], array $body = []): Result
+    public function endPrediction(array $parameters = [], array $body = []): Result
     {
         $this->validateRequired($body, [
             'broadcaster_id',

--- a/src/Concerns/Api/PredictionsTrait.php
+++ b/src/Concerns/Api/PredictionsTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace romanzipp\Twitch\Concerns\Api;
+
+use romanzipp\Twitch\Concerns\Operations\AbstractOperationsTrait;
+use romanzipp\Twitch\Concerns\Operations\AbstractValidationTrait;
+use romanzipp\Twitch\Objects\Paginator;
+use romanzipp\Twitch\Result;
+
+trait PredictionsTrait
+{
+    use AbstractOperationsTrait;
+    use AbstractValidationTrait;
+
+    public function getPredictions(array $parameters = [], Paginator $paginator = null): Result
+    {
+        $this->validateRequired($parameters, ['broadcaster_id']);
+
+        return $this->get('predictions', $parameters, $paginator);
+    }
+
+    public function createPredictions(array $parameters = [], array $body = []): Result
+    {
+        $this->validateRequired($body, [
+            'broadcaster_id',
+            'title',
+            'outcomes',
+            'outcome.title',
+            'prediction_window',
+        ]);
+
+        return $this->post('predictions', $parameters, null, $body);
+    }
+
+    public function updatePrediction(array $parameters = [], array $body = []): Result
+    {
+        $this->validateRequired($body, [
+            'broadcaster_id',
+            'id',
+            'status',
+        ]);
+
+        return $this->patch('predictions', $parameters, null, $body);
+    }
+}

--- a/src/Enums/EventSubType.php
+++ b/src/Enums/EventSubType.php
@@ -78,4 +78,25 @@ class EventSubType
 
     // Triggers whenever a hype train ends on a broadcaster's channel.
     public const CHANNEL_HYPE_TRAIN_END = 'channel.hype_train.end';
+
+    // Triggers whenever a poll started on a specified channel.
+    public const CHANNEL_POLL_BEGIN = 'channel.poll.begin';
+
+    // Triggers whenever a user respond to a poll on a specified channel.
+    public const CHANNEL_POLL_PROGRESS = 'channel.poll.progress';
+
+    // Triggers whenever a poll ended on a specified channel.
+    public const CHANNEL_POLL_END = 'channel.poll.end';
+
+    // Triggers whenever a Channel Points Prediction started on a specified channel.
+    public const CHANNEL_PREDICTION_BEGIN = 'channel.prediction.begin';
+
+    // Triggers whenever a user participated in a Channel Points Prediction on a specified channel.
+    public const CHANNEL_PREDICTION_PROGRESS = 'channel.prediction.progress';
+
+    // Triggers whenever a Channel Points Prediction was locked on a specified channel.
+    public const CHANNEL_PREDICTION_LOCK = 'channel.prediction.lock';
+
+    // Triggers whenever a Channel Points Prediction ended on a specified channel.
+    public const CHANNEL_PREDICTION_END = 'channel.prediction.end';
 }

--- a/src/Enums/PollStatus.php
+++ b/src/Enums/PollStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace romanzipp\Twitch\Enums;
+
+class PollStatus
+{
+    // Poll is currently in progress.
+    public const ACTIVE = 'ACTIVE';
+
+    // Poll has reached its ended_at time.
+    public const COMPLETED = 'COMPLETED';
+
+    // Poll has been manually terminated before its ended_at time.
+    public const TERMINATED = 'TERMINATED';
+
+    // Poll is no longer visible on the channel.
+    public const ARCHIVED = 'ARCHIVED';
+
+    // Poll is no longer visible to any user.
+    public const MODERATED = 'MODERATED';
+
+    // Something went wrong determining the state.
+    public const INVALID = 'INVALID';
+}

--- a/src/Enums/PredictionOutcomeColor.php
+++ b/src/Enums/PredictionOutcomeColor.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace romanzipp\Twitch\Enums;
+
+class PredictionOutcomeColor
+{
+    public const BLUE = 'BLUE';
+
+    public const PINK = 'PINK';
+}

--- a/src/Enums/PredictionStatus.php
+++ b/src/Enums/PredictionStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace romanzipp\Twitch\Enums;
+
+class PredictionStatus
+{
+    // Definition pending.
+    public const RESOLVED = 'RESOLVED';
+
+    // Definition pending.
+    public const RESOLVED_PENDING = 'RESOLVED_PENDING';
+
+    // Definition pending.
+    public const ACTIVE = 'ACTIVE';
+
+    // Definition pending.
+    public const CANCELED = 'CANCELED';
+
+    // Definition pending.
+    public const CANCEL_PENDING = 'CANCEL_PENDING';
+
+    // Definition pending.
+    public const LOCKED = 'LOCKED';
+}

--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -28,6 +28,12 @@ class Scope
     // Manage a channel’s Extension configuration, including activating Extensions.
     public const CHANNEL_MANAGE_EXTENSIONS = 'channel:manage:extensions';
 
+    // Manage a Poll for a specific channel.
+    public const CHANNEL_MANAGE_POLLS = 'channel:manage:polls';
+
+    // Manage a Channel Points Prediction for a specific channel.
+    public const CHANNEL_MANAGE_PREDICTIONS = 'channel:manage:predictions';
+
     // Manage Channel Points custom rewards and their redemptions on a channel.
     public const CHANNEL_MANAGE_REDEMPTIONS = 'channel:manage:redemptions';
 
@@ -39,6 +45,12 @@ class Scope
 
     // View Hype Train information for a channel.
     public const CHANNEL_READ_HYPE_TRAIN = 'channel:read:hype_train';
+
+    // View information about all Polls or specific Polls for a channel.
+    public const CHANNEL_READ_POLLS = 'channel:read:polls';
+
+    // View information about all Channel Points Predictions or specific Channel Points Predictions for a channel.
+    public const CHANNEL_READ_PREDICTIONS = 'channel:read:predictions';
 
     // View Channel Points custom rewards and their redemptions on a channel.
     public const CHANNEL_READ_REDEMPTIONS = 'channel:read:redemptions';

--- a/src/Twitch.php
+++ b/src/Twitch.php
@@ -25,6 +25,8 @@ class Twitch
     use Api\ExtensionsTrait;
     use Api\GamesTrait;
     use Api\HypeTrainTrait;
+    use Api\PollsTrait;
+    use Api\PredictionsTrait;
     use Api\SearchTrait;
     use Api\StreamsTrait;
     use Api\UsersTrait;

--- a/tests/Api/PollsTest.php
+++ b/tests/Api/PollsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace romanzipp\Twitch\Tests\Api;
+
+use romanzipp\Twitch\Enums\PollStatus;
+use romanzipp\Twitch\Tests\TestCases\ApiTestCase;
+
+class PollsTest extends ApiTestCase
+{
+    public function testGetPolls()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $this->registerResult(
+            $result = $this->twitch()->withToken($this->getToken())->getPolls([
+                'broadcaster_id' => $this->getBroadcasterId(),
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+    }
+
+    public function testCreatePolls()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $this->registerResult(
+            $result = $this->twitch()->withToken($this->getToken())->createPolls([], [
+                'broadcaster_id' => $this->getBroadcasterId(),
+                'title' => 'Hello World!',
+                'choices' => [
+                    [
+                        'title' => 'A eSports',
+                    ],
+                    [
+                        'title' => 'B eSports',
+                    ],
+                ],
+                'duration' => 30,
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+    }
+
+    /**
+     * @depends testCreatePolls
+     */
+    public function testEndPoll()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $poll = $this->twitch()->withToken($this->getToken())->getPolls([
+            'broadcaster_id' => $this->getBroadcasterId(),
+        ])->shift();
+
+        if ( ! $poll) {
+            self::markTestSkipped('No Poll provided');
+        }
+
+        $this->registerResult(
+            $result = $this->twitch()->updatePoll([], [
+                'broadcaster_id' => '106415581',
+                'id' => $poll->id,
+                'status' => PollStatus::TERMINATED,
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+        self::assertNotEmpty($result->data());
+    }
+}

--- a/tests/Api/PollsTest.php
+++ b/tests/Api/PollsTest.php
@@ -27,7 +27,7 @@ class PollsTest extends ApiTestCase
         $this->skipIfBroadcasterIdMissing();
 
         $this->registerResult(
-            $result = $this->twitch()->withToken($this->getToken())->createPolls([], [
+            $result = $this->twitch()->withToken($this->getToken())->createPoll([], [
                 'broadcaster_id' => $this->getBroadcasterId(),
                 'title' => 'Hello World!',
                 'choices' => [
@@ -62,7 +62,7 @@ class PollsTest extends ApiTestCase
         }
 
         $this->registerResult(
-            $result = $this->twitch()->updatePoll([], [
+            $result = $this->twitch()->endPoll([], [
                 'broadcaster_id' => '106415581',
                 'id' => $poll->id,
                 'status' => PollStatus::TERMINATED,

--- a/tests/Api/PredictionsTest.php
+++ b/tests/Api/PredictionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace romanzipp\Twitch\Tests\Api;
+
+use romanzipp\Twitch\Enums\PredictionStatus;
+use romanzipp\Twitch\Tests\TestCases\ApiTestCase;
+
+class PredictionsTest extends ApiTestCase
+{
+    public function testGetPredictions()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $this->registerResult(
+            $result = $this->twitch()->withToken($this->getToken())->getPredictions([
+                'broadcaster_id' => $this->getBroadcasterId(),
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+    }
+
+    public function testCreatePredictions()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $this->registerResult(
+            $result = $this->twitch()->withToken($this->getToken())->createPredictions([], [
+                'broadcaster_id' => $this->getBroadcasterId(),
+                'title' => 'Hello World!',
+                'outcomes' => [
+                    [
+                        'title' => 'A eSports',
+                    ],
+                    [
+                        'title' => 'B eSports',
+                    ],
+                ],
+                'prediction_window' => 30,
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+    }
+
+    /**
+     * @depends testCreatePredictions
+     */
+    public function testEndPrediction()
+    {
+        $this->skipIfTokenMissing();
+        $this->skipIfBroadcasterIdMissing();
+
+        $prediction = $this->twitch()->withToken($this->getToken())->getPredictions([
+            'broadcaster_id' => $this->getBroadcasterId(),
+        ])->shift();
+
+        if ( ! $prediction) {
+            self::markTestSkipped('No Prediction provided');
+        }
+
+        $this->registerResult(
+            $result = $this->twitch()->updatePrediction([], [
+                'broadcaster_id' => '106415581',
+                'id' => $prediction->id,
+                'status' => PredictionStatus::CANCELED,
+            ])
+        );
+
+        self::assertTrue($result->success(), $result->getErrorMessage());
+        self::assertNotEmpty($result->data());
+    }
+}

--- a/tests/Api/PredictionsTest.php
+++ b/tests/Api/PredictionsTest.php
@@ -27,7 +27,7 @@ class PredictionsTest extends ApiTestCase
         $this->skipIfBroadcasterIdMissing();
 
         $this->registerResult(
-            $result = $this->twitch()->withToken($this->getToken())->createPredictions([], [
+            $result = $this->twitch()->withToken($this->getToken())->createPrediction([], [
                 'broadcaster_id' => $this->getBroadcasterId(),
                 'title' => 'Hello World!',
                 'outcomes' => [
@@ -62,7 +62,7 @@ class PredictionsTest extends ApiTestCase
         }
 
         $this->registerResult(
-            $result = $this->twitch()->updatePrediction([], [
+            $result = $this->twitch()->endPrediction([], [
                 'broadcaster_id' => '106415581',
                 'id' => $prediction->id,
                 'status' => PredictionStatus::CANCELED,

--- a/tests/TestCases/ApiTestCase.php
+++ b/tests/TestCases/ApiTestCase.php
@@ -71,4 +71,22 @@ abstract class ApiTestCase extends TestCase
 
         self::markTestSkipped('No Client-ID provided');
     }
+
+    protected function skipIfTokenMissing()
+    {
+        if ($this->getToken()) {
+            return;
+        }
+
+        self::markTestSkipped('No Access-Token provided');
+    }
+
+    protected function skipIfBroadcasterIdMissing()
+    {
+        if ($this->getBroadcasterId()) {
+            return;
+        }
+
+        self::markTestSkipped('No Broadcaster-ID provided');
+    }
 }

--- a/tests/TestCases/TestCase.php
+++ b/tests/TestCases/TestCase.php
@@ -36,6 +36,16 @@ abstract class TestCase extends BaseTestCase
         return getenv('CLIENT_ID');
     }
 
+    protected function getToken()
+    {
+        return getenv('ACCESS_TOKEN');
+    }
+
+    protected function getBroadcasterId()
+    {
+        return getenv('BROADCASTER_ID');
+    }
+
     protected function getMockedService($mockedResponse): Twitch
     {
         $twitch = new Twitch();


### PR DESCRIPTION
Twitch released two new products for public beta today. For more information about the beta classification, see [Product Lifecycle](https://dev.twitch.tv/docs/product-lifecycle).

I am currently still unsure with the following namings:

- Should it be called `createPolls` or `createPoll`?
- Should it be `updatePoll` or `endPoll` (because of the `PATCH`-Method)?
- Should it be `createPredictions` or `createPrediction`?
- Should it be `updatePrediction` or `endPrediction` (because of the `PATCH`-Method)?

For `createCustomRewards` it is also plural. But you actually create only one reward. I would go with singular.

Also there are now the two new environment variables for testing:

- `BROADCASTER_ID` (ID of the user to test for)
- `ACCESS_TOKEN` (Access Token of the user to be tested)

