### PR TITLE
remove broadcaster_id from required parameters in cheermotes

### DIFF
--- a/src/Concerns/Api/BitsTrait.php
+++ b/src/Concerns/Api/BitsTrait.php
@@ -23,8 +23,6 @@ trait BitsTrait
      */
     public function getCheermotes(array $parameters = []): Result
     {
-        $this->validateRequired($parameters, ['broadcaster_id']);
-
         return $this->get('bits/cheermotes', $parameters);
     }
 


### PR DESCRIPTION
`broadcaster_id` is an optional parameter in the bits/cheermotes endpoint

https://dev.twitch.tv/docs/api/reference#get-cheermotes