### PR TITLE
added channel goal eventsub topics and scopes

### DIFF
--- a/src/Enums/EventSubType.php
+++ b/src/Enums/EventSubType.php
@@ -121,4 +121,13 @@ class EventSubType
 
     // Triggers whenever a Bits transaction occurred for a specified Twitch Extension.
     public const EXTENSION_BITS_TRANSACTION_CREATE = 'extension.bits_transaction.create';
+
+    // Triggers whenever a Channel Goal started on a specific channel.
+    public const CHANNEL_GOAL_BEGIN = 'channel.goal.begin';
+
+    // Triggers whenever a user participated in a Channel Goal on a specific channel.
+    public const CHANNEL_GOAL_PROGRESS = 'channel.goal.progress';
+
+    // Triggers whenever a Channel Goal ended on a specific channel.
+    public const CHANNEL_GOAL_END = 'channel.goal.end';
 }

--- a/src/Enums/Scope.php
+++ b/src/Enums/Scope.php
@@ -174,4 +174,7 @@ class Scope
 
     // Turn on Viewer Heartbeat Service ability to record user data.
     public const V5_VIEWING_ACTIVITY_READ = 'viewing_activity_read';
+
+    // Read a channel’s goals.
+    public const CHANNEL_READ_GOALS = 'channel:read:goals';
 }


### PR DESCRIPTION
Back in October 2021, Twitch added [Creator Goals](https://dev.twitch.tv/docs/api/goals) in the API and EventSub.
This pull request adds the required scopes and EventSub topics.