### PR TITLE
Rewrite credentials management

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,88 @@ $twitch->unsubscribeEventSub([
 ]);
 ```
 
+### Credentials Repository
+
+> **Intermediate**: This section is for advanced users only. If you are not sure what this is about, you can skip this section.
+> If you plan to share your twitch credentials between multiple applications (with different caches), you should use a secret manager
+> like [Google Secret Manager](https://cloud.google.com/secret-manager) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
+
+Currently, there are three different ways to obtain an access token:
+
+- Client Credentials Flow (`TwitchClientCredentialsRepository`)
+- Google Secret Manager (`GoogleClientCredentialsRepository`)
+- AWS Secrets Manager (`AwsClientCredentialsRepository`)
+
+#### Client Credentials Flow
+
+The Client Credentials Flow is the most common way to obtain an access token. It is used by the `TwitchClientCredentialsRepository` class.
+
+No additional configuration is required.
+
+#### Google Secret Manager
+
+The Google Secret Manager is a secret manager provided by Google Cloud. It is used by the `GoogleClientCredentialsRepository` class.
+
+To use the Google Secret Manager, you must install the `google/cloud-secret-manager` package.
+
+```bash
+composer require google/cloud-secret-manager
+```
+
+Next, you must set the following environment variables (adjust the values to your needs):
+    
+```dotenv
+TWITCH_HELIX_SECRET_MANAGER_PROJECT_ID=your-project-id
+TWITCH_HELIX_SECRET_MANAGER_SECRET_ID=your-secret-id
+TWITCH_HELIX_SECRET_MANAGER_SECRET_VERSION=latest
+```
+
+Usually Google will use ADC (Application Default Credentials) to authenticate. If you want to use a service account, you can set the following environment variables:
+
+```dotenv
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account.json
+```
+
+Otherwise, ADC will check a known file system location that is user-specific for a JSON file created by the gcloud command-line tool.
+
+On Windows, `%APPDATA%/gcloud/application_default_credentials.json`.
+On other systems, `$HOME/.config/gcloud/application_default_credentials.json`.
+
+However, you can also re-bind the `SecretManagerServiceClient` class in your application's service container.
+
+#### AWS Secrets Manager
+
+The AWS Secrets Manager is a secret manager provided by Amazon Web Services. It is used by the `AwsClientCredentialsRepository` class.
+
+To use the AWS Secrets Manager, you must install the `aws/aws-sdk-php` package.
+
+```bash
+composer require aws/aws-sdk-php
+```
+
+Next, you must set the following environment variables (adjust the values to your needs):
+    
+```dotenv
+TWITCH_HELIX_SECRET_MANAGER_SECRET_ID=your-secret-id
+```
+
+When using the AWS Secrets Manager, you must bind the `Aws\SecretsManager\SecretsManagerClient` to the container:
+
+```php
+use Aws\SecretsManager\SecretsManagerClient;
+
+public function register()
+{
+    $this->app->bind(SecretsManagerClient::class, function () {
+        return new SecretsManagerClient([
+            'profile' => 'default',
+            'version' => '2017-10-17',
+            'region' => '<<{{MyRegionName}}>>',
+        ]);
+    });
+}
+```
+
 ## Documentation
 
 **Twitch Helix API Documentation: https://dev.twitch.tv/docs/api/reference**

--- a/README.stub.md
+++ b/README.stub.md
@@ -326,6 +326,88 @@ $twitch->unsubscribeEventSub([
 ]);
 ```
 
+### Credentials Repository
+
+> **Intermediate**: This section is for advanced users only. If you are not sure what this is about, you can skip this section.
+> If you plan to share your twitch credentials between multiple applications (with different caches), you should use a secret manager
+> like [Google Secret Manager](https://cloud.google.com/secret-manager) or [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
+
+Currently, there are three different ways to obtain an access token:
+
+- Client Credentials Flow (`TwitchClientCredentialsRepository`)
+- Google Secret Manager (`GoogleClientCredentialsRepository`)
+- AWS Secrets Manager (`AwsClientCredentialsRepository`)
+
+#### Client Credentials Flow
+
+The Client Credentials Flow is the most common way to obtain an access token. It is used by the `TwitchClientCredentialsRepository` class.
+
+No additional configuration is required.
+
+#### Google Secret Manager
+
+The Google Secret Manager is a secret manager provided by Google Cloud. It is used by the `GoogleClientCredentialsRepository` class.
+
+To use the Google Secret Manager, you must install the `google/cloud-secret-manager` package.
+
+```bash
+composer require google/cloud-secret-manager
+```
+
+Next, you must set the following environment variables (adjust the values to your needs):
+    
+```dotenv
+TWITCH_HELIX_SECRET_MANAGER_PROJECT_ID=your-project-id
+TWITCH_HELIX_SECRET_MANAGER_SECRET_ID=your-secret-id
+TWITCH_HELIX_SECRET_MANAGER_SECRET_VERSION=latest
+```
+
+Usually Google will use ADC (Application Default Credentials) to authenticate. If you want to use a service account, you can set the following environment variables:
+
+```dotenv
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account.json
+```
+
+Otherwise, ADC will check a known file system location that is user-specific for a JSON file created by the gcloud command-line tool.
+
+On Windows, `%APPDATA%/gcloud/application_default_credentials.json`.
+On other systems, `$HOME/.config/gcloud/application_default_credentials.json`.
+
+However, you can also re-bind the `SecretManagerServiceClient` class in your application's service container.
+
+#### AWS Secrets Manager
+
+The AWS Secrets Manager is a secret manager provided by Amazon Web Services. It is used by the `AwsClientCredentialsRepository` class.
+
+To use the AWS Secrets Manager, you must install the `aws/aws-sdk-php` package.
+
+```bash
+composer require aws/aws-sdk-php
+```
+
+Next, you must set the following environment variables (adjust the values to your needs):
+    
+```dotenv
+TWITCH_HELIX_SECRET_MANAGER_SECRET_ID=your-secret-id
+```
+
+When using the AWS Secrets Manager, you must bind the `Aws\SecretsManager\SecretsManagerClient` to the container:
+
+```php
+use Aws\SecretsManager\SecretsManagerClient;
+
+public function register()
+{
+    $this->app->bind(SecretsManagerClient::class, function () {
+        return new SecretsManagerClient([
+            'profile' => 'default',
+            'version' => '2017-10-17',
+            'region' => '<<{{MyRegionName}}>>',
+        ]);
+    });
+}
+```
+
 ## Documentation
 
 **Twitch Helix API Documentation: https://dev.twitch.tv/docs/api/reference**

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
         "illuminate/cache": "^5.5|^6.0|^7.0|^8.0|^9.0",
@@ -19,7 +19,9 @@
         "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0"
     },
     "require-dev": {
+        "aws/aws-sdk-php": "^3.257",
         "friendsofphp/php-cs-fixer": "^3.0",
+        "google/cloud-secret-manager": "^1.9",
         "mockery/mockery": "^1.3.2",
         "orchestra/testbench": "^3.8|^4.0|^5.0|^6.0",
         "phpstan/phpstan": "^0.12.99|^1.0",
@@ -49,6 +51,10 @@
                 "Twitch": "romanzipp\\Twitch\\Facades\\Twitch"
             }
         }
+    },
+    "suggest": {
+        "google/cloud-secret-manager": "Rquired to use the google cloud secret manager (^1.9).",
+        "aws/aws-sdk-php": "Rquired to use the aws secret manager (^3.0)."
     },
     "config": {
         "sort-packages": true

--- a/config/twitch-api.php
+++ b/config/twitch-api.php
@@ -1,5 +1,7 @@
 <?php
 
+use romanzipp\Twitch\Repositories\TwitchClientCredentialsRepository;
+
 return [
     /*
      * The Client ID to use for requests.
@@ -17,6 +19,17 @@ return [
     'redirect_url' => env('TWITCH_HELIX_REDIRECT_URI'),
 
     'oauth_client_credentials' => [
+
+        /*
+         * You can choose between the following oauth client credentials cache stores:
+         *  - TwitchClientCredentialsRepository
+         *  - GoogleClientCredentialsRepository
+         *  - AwsClientCredentialsRepository
+         *
+         * We recommend using RedisClientCredentialsRepository for most use cases.
+         */
+        'provider' => TwitchClientCredentialsRepository::class,
+
         /*
          * Since May 01, 2020, Twitch requires all API requests to contain a valid Access Token.
          * This can be achieved with the Client Credentials flow.
@@ -40,6 +53,28 @@ return [
          * The cache key to use for storing information.
          */
         'cache_key' => 'twitch-api-client-credentials',
+
+        /*
+         * Configurations for the different credential providers.
+         */
+        'secret_manager' => [
+
+            /*
+             * Google secret manager configuration.
+             */
+            'google' => [
+                'project_id' => env('TWITCH_HELIX_SECRET_MANAGER_PROJECT_ID'),
+                'secret_id' => env('TWITCH_HELIX_SECRET_MANAGER_SECRET_ID', 'twitch_access_token'),
+                'secret_version' => env('TWITCH_HELIX_SECRET_MANAGER_SECRET_VERSION', 'latest'),
+            ],
+
+            /*
+             * Amazon secret manager configuration.
+             */
+            'aws' => [
+                'secret_id' => env('TWITCH_HELIX_SECRET_MANAGER_SECRET_ID', 'twitch_access_token'),
+            ],
+        ],
     ],
 
     'eventsub' => [

--- a/src/Concerns/ClientCredentialsTrait.php
+++ b/src/Concerns/ClientCredentialsTrait.php
@@ -2,143 +2,14 @@
 
 namespace romanzipp\Twitch\Concerns;
 
-use Illuminate\Contracts\Cache\Repository;
-use Illuminate\Support\Facades\Cache;
 use romanzipp\Twitch\Enums\GrantType;
-use romanzipp\Twitch\Exceptions\OAuthTokenRequestException;
-use romanzipp\Twitch\Objects\AccessToken;
 use romanzipp\Twitch\Result;
 
 trait ClientCredentialsTrait
 {
-    /**
-     * Determine if an OAuth token should be fetched via the Client Credentials flow.
-     *
-     * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow
-     *
-     * @return bool
-     */
-    protected function shouldFetchClientCredentials(): bool
-    {
-        return config('twitch-api.oauth_client_credentials.auto_generate')
-            && null !== $this->getClientId()
-            && null !== $this->getClientSecret();
-    }
-
-    /**
-     * Determine if the client credentials should be cached.
-     *
-     * @return bool
-     */
-    protected function shouldCacheClientCredentials(): bool
-    {
-        return config('twitch-api.oauth_client_credentials.cache');
-    }
-
-    /**
-     * Fetch and possibly cache the OAuth token.
-     *
-     * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow
-     *
-     * @return \romanzipp\Twitch\Objects\AccessToken|null
-     */
-    protected function getClientCredentials(): ?AccessToken
-    {
-        if ($this->shouldCacheClientCredentials() && $token = $this->getCachedClientCredentialsToken()) {
-            return $token;
-        }
-
-        $result = $this->getOAuthToken(null, GrantType::CLIENT_CREDENTIALS);
-
-        if ( ! $result->success()) {
-            $exception = $result->getException();
-
-            if (null === $exception) {
-                return null;
-            }
-
-            throw new OAuthTokenRequestException('Could not fetch the OAuth credentials', $exception->getRequest(), $result->getResponse(), $exception);
-        }
-
-        $token = new AccessToken(
-            (array) $result->data()
-        );
-
-        if ($this->shouldCacheClientCredentials()) {
-            $this->storeClientCredentialsToken($token);
-        }
-
-        return $token;
-    }
-
-    /**
-     * Possibly get a cached and not-expired version of the Access Token.
-     *
-     * @return \romanzipp\Twitch\Objects\AccessToken|null
-     *
-     * @noinspection PhpDocMissingThrowsInspection
-     */
-    protected function getCachedClientCredentialsToken(): ?AccessToken
-    {
-        $key = config('twitch-api.oauth_client_credentials.cache_key');
-
-        $stored = $this->getClientCredentialsCacheRepository()->get($key);
-
-        if (empty($stored)) {
-            return null;
-        }
-
-        $token = new AccessToken($stored);
-
-        if ( ! $token->isExpired()) {
-            return $token;
-        }
-
-        $this->getClientCredentialsCacheRepository()->delete($key);
-
-        return null;
-    }
-
-    /**
-     * Store the client credentials in cache.
-     *
-     * @param \romanzipp\Twitch\Objects\AccessToken $token
-     *
-     * @noinspection PhpDocMissingThrowsInspection
-     */
-    protected function storeClientCredentialsToken(AccessToken $token): void
-    {
-        $this->getClientCredentialsCacheRepository()->set(
-            config('twitch-api.oauth_client_credentials.cache_key'),
-            $token->toArray()
-        );
-    }
-
-    /**
-     * Clear the client credentials from cache.
-     */
-    protected function clearClientCredentialsToken(): void
-    {
-        $this->getClientCredentialsCacheRepository()->forget(
-            config('twitch-api.oauth_client_credentials.cache_key')
-        );
-    }
-
-    /**
-     * Get the cache driver instance used for storing the client credentials.
-     *
-     * @return \Illuminate\Contracts\Cache\Repository
-     */
-    protected function getClientCredentialsCacheRepository(): Repository
-    {
-        return Cache::store(
-            config('twitch-api.oauth_client_credentials.cache_store')
-        );
-    }
-
     public function isAuthenticationUri(string $uri): bool
     {
-        return 0 === strpos($uri, self::OAUTH_BASE_URI);
+        return str_starts_with($uri, self::OAUTH_BASE_URI);
     }
 
     abstract public function getOAuthToken(?string $code = null, string $grantType = GrantType::AUTHORIZATION_CODE, array $scopes = []): Result;

--- a/src/Contracts/ClientCredentialsRepository.php
+++ b/src/Contracts/ClientCredentialsRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace romanzipp\Twitch\Contracts;
+
+use romanzipp\Twitch\Objects\AccessToken;
+use romanzipp\Twitch\Twitch;
+
+interface ClientCredentialsRepository
+{
+    /**
+     * Determine if an OAuth token should be fetched via the implemented flow.
+     */
+    public function shouldFetchClientCredentials(): bool;
+
+    /**
+     * Determine if the client credentials should be cached.
+     */
+    public function shouldCacheClientCredentials(): bool;
+
+    /**
+     * Fetch and possibly cache the OAuth token.
+     */
+    public function getClientCredentials(Twitch $twitch): ?AccessToken;
+
+    /**
+     * Store the client credentials in cache.
+     */
+    public function storeClientCredentialsToken(AccessToken $token): void;
+
+    /**
+     * Clear the client credentials from cache.
+     */
+    public function clearClientCredentialsToken(): void;
+}

--- a/src/Exceptions/OAuthTokenRequestException.php
+++ b/src/Exceptions/OAuthTokenRequestException.php
@@ -2,8 +2,9 @@
 
 namespace romanzipp\Twitch\Exceptions;
 
-use GuzzleHttp\Exception\RequestException;
+use Exception;
 
-class OAuthTokenRequestException extends RequestException
+class OAuthTokenRequestException extends Exception
 {
+
 }

--- a/src/Objects/AccessToken.php
+++ b/src/Objects/AccessToken.php
@@ -72,4 +72,17 @@ class AccessToken implements Arrayable
 
         return time() > $this->expiresAt;
     }
+
+    public function fromJsonOrString(string $jsonOrString): self
+    {
+        if (!str_contains($jsonOrString, '{')) {
+            return new self([
+                'access_token' => $jsonOrString,
+                'expires_in' => 86400,
+                'token_type' => 'client_credentials',
+            ]);
+        }
+
+        return new self(json_decode($jsonOrString, true));
+    }
 }

--- a/src/Providers/TwitchServiceProvider.php
+++ b/src/Providers/TwitchServiceProvider.php
@@ -3,6 +3,7 @@
 namespace romanzipp\Twitch\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use romanzipp\Twitch\Contracts\ClientCredentialsRepository;
 use romanzipp\Twitch\Twitch;
 
 class TwitchServiceProvider extends ServiceProvider
@@ -28,6 +29,11 @@ class TwitchServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(
             dirname(__DIR__) . '/../config/twitch-api.php', 'twitch-api'
+        );
+
+        $this->app->singleton(
+            ClientCredentialsRepository::class,
+            config('twitch-api.oauth_client_credentials.provider')
         );
 
         $this->app->singleton(Twitch::class, function () {

--- a/src/Repositories/AwsClientCredentialsRepository.php
+++ b/src/Repositories/AwsClientCredentialsRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace romanzipp\Twitch\Repositories;
+
+use Aws\Exception\AwsException;
+use Aws\SecretsManager\SecretsManagerClient;
+use romanzipp\Twitch\Exceptions\OAuthTokenRequestException;
+use romanzipp\Twitch\Objects\AccessToken;
+use romanzipp\Twitch\Twitch;
+
+class AwsClientCredentialsRepository extends ClientCredentialsRepository
+{
+    private SecretsManagerClient $client;
+
+    public function __construct(SecretsManagerClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @throws OAuthTokenRequestException
+     */
+    public function getClientCredentials(Twitch $twitch): ?AccessToken
+    {
+        if ($this->shouldCacheClientCredentials() && $token = $this->getCachedClientCredentialsToken()) {
+            return $token;
+        }
+
+        $token = AccessToken::fromJsonOrString($this->getSecretPayload());
+
+        if ($this->shouldCacheClientCredentials()) {
+            $this->storeClientCredentialsToken($token);
+        }
+
+        return $token;
+    }
+
+    /**
+     * @throws OAuthTokenRequestException
+     */
+    public function getSecretPayload(): string
+    {
+        try {
+            $result = $this->client->getSecretValue([
+                'SecretId' => config('twitch-api.oauth_client_credentials.secret_manager.aws.secret_id'),
+            ]);
+        } catch (AwsException $exception) {
+            throw new OAuthTokenRequestException('Could not fetch the OAuth access token from AWS.', $exception->getCode(), $exception);
+        }
+
+        if (isset($result['SecretString'])) {
+            return $result['SecretString'];
+        } else {
+            return base64_decode($result['SecretBinary']);
+        }
+    }
+}

--- a/src/Repositories/ClientCredentialsRepository.php
+++ b/src/Repositories/ClientCredentialsRepository.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace romanzipp\Twitch\Repositories;
+
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Support\Facades\Cache;
+use Psr\SimpleCache\InvalidArgumentException;
+use romanzipp\Twitch\Contracts\ClientCredentialsRepository as Repository;
+use romanzipp\Twitch\Exceptions\OAuthTokenRequestException;
+use romanzipp\Twitch\Objects\AccessToken;
+use romanzipp\Twitch\Twitch;
+
+abstract class ClientCredentialsRepository implements Repository
+{
+    /**
+     * Determine if an OAuth token should be fetched via the implemented flow.
+     */
+    public function shouldFetchClientCredentials(): bool
+    {
+        return config('twitch-api.oauth_client_credentials.auto_generate');
+    }
+
+    /**
+     * Determine if the client credentials should be cached.
+     */
+    public function shouldCacheClientCredentials(): bool
+    {
+        return config('twitch-api.oauth_client_credentials.cache');
+    }
+
+    /**
+     * Get the cache driver instance used for storing the client credentials.
+     */
+    protected function getClientCredentialsCacheRepository(): CacheRepository
+    {
+        return Cache::store(
+            config('twitch-api.oauth_client_credentials.cache_store')
+        );
+    }
+
+    protected function getCacheKey(): string
+    {
+        return config('twitch-api.oauth_client_credentials.cache_key');
+    }
+
+    /**
+     * Fetch and possibly cache the OAuth token.
+     *
+     * @throws OAuthTokenRequestException
+     * @throws InvalidArgumentException
+     */
+    abstract public function getClientCredentials(Twitch $twitch): ?AccessToken;
+
+    /**
+     * Possibly get a cached and not-expired version of the Access Token.
+     *
+     * @return AccessToken|null
+     * @throws InvalidArgumentException
+     */
+    protected function getCachedClientCredentialsToken(): ?AccessToken
+    {
+        $stored = $this->getClientCredentialsCacheRepository()->get($this->getCacheKey());
+
+        if (empty($stored)) {
+            return null;
+        }
+
+        $token = new AccessToken($stored);
+
+        if ( ! $token->isExpired()) {
+            return $token;
+        }
+
+        $this->getClientCredentialsCacheRepository()->delete($this->getCacheKey());
+
+        return null;
+    }
+
+    /**
+     * Store the client credentials in cache.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function storeClientCredentialsToken(AccessToken $token): void
+    {
+        $this->getClientCredentialsCacheRepository()->set($this->getCacheKey(), $token->toArray());
+    }
+
+    /**
+     * Clear the client credentials from cache.
+     */
+    public function clearClientCredentialsToken(): void
+    {
+        $this->getClientCredentialsCacheRepository()->forget($this->getCacheKey());
+    }
+}
+

--- a/src/Repositories/GoogleClientCredentialsRepository.php
+++ b/src/Repositories/GoogleClientCredentialsRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace romanzipp\Twitch\Repositories;
+
+use Google\ApiCore\ApiException;
+use Google\Cloud\SecretManager\V1\SecretManagerServiceClient;
+use romanzipp\Twitch\Exceptions\OAuthTokenRequestException;
+use romanzipp\Twitch\Objects\AccessToken;
+use romanzipp\Twitch\Twitch;
+
+class GoogleClientCredentialsRepository extends ClientCredentialsRepository
+{
+    private SecretManagerServiceClient $client;
+
+    public function __construct(SecretManagerServiceClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function getClientCredentials(Twitch $twitch): ?AccessToken
+    {
+        if ($this->shouldCacheClientCredentials() && $token = $this->getCachedClientCredentialsToken()) {
+            return $token;
+        }
+
+        $token = AccessToken::fromJsonOrString($this->getSecretPayload());
+
+        if ($this->shouldCacheClientCredentials()) {
+            $this->storeClientCredentialsToken($token);
+        }
+
+        return $token;
+    }
+
+    /**
+     * @throws OAuthTokenRequestException
+     */
+    public function getSecretPayload(): string
+    {
+        $name = $this->client->secretVersionName(
+            config('twitch-api.oauth_client_credentials.secret_manager.google.project_id'),
+            config('twitch-api.oauth_client_credentials.secret_manager.google.secret_id'),
+            config('twitch-api.oauth_client_credentials.secret_manager.google.secret_version')
+        );
+
+        try {
+            $result = $this->client->accessSecretVersion($name);
+        } catch (ApiException $exception) {
+            throw new OAuthTokenRequestException('Could not fetch the OAuth access token from Google.', $exception->getCode(), $exception);
+        }
+
+        return $result->getPayload()->getData();
+    }
+}

--- a/src/Repositories/TwitchClientCredentialsRepository.php
+++ b/src/Repositories/TwitchClientCredentialsRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace romanzipp\Twitch\Repositories;
+
+use Psr\SimpleCache\InvalidArgumentException;
+use romanzipp\Twitch\Enums\GrantType;
+use romanzipp\Twitch\Exceptions\OAuthTokenRequestException;
+use romanzipp\Twitch\Objects\AccessToken;
+use romanzipp\Twitch\Twitch;
+
+class TwitchClientCredentialsRepository extends ClientCredentialsRepository
+{
+    /**
+     * @inheritdoc
+     *
+     * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-client-credentials-flow
+     */
+    public function getClientCredentials(Twitch $twitch): ?AccessToken
+    {
+        if ($this->shouldCacheClientCredentials() && $token = $this->getCachedClientCredentialsToken()) {
+            return $token;
+        }
+
+        $result = $twitch->getOAuthToken(null, GrantType::CLIENT_CREDENTIALS);
+
+        if ( ! $result->success()) {
+            $exception = $result->getException();
+
+            if (null === $exception) {
+                return null;
+            }
+
+            throw new OAuthTokenRequestException('Could not fetch the OAuth access token from Twitch.', $exception->getCode(), $exception);
+        }
+
+        $token = new AccessToken((array) $result->data());
+
+        if ($this->shouldCacheClientCredentials()) {
+            $this->storeClientCredentialsToken($token);
+        }
+
+        return $token;
+    }
+
+}


### PR DESCRIPTION
> This is an Intermediate feature (opt-in). Most user will not use it, unless you use Laravel-Twitch on large environments, like i do.

Hey, I have the use-case where i need to override the credentials management based on different providers, like "Google Secret Manager" and other providers like AWS, or even custom providers. In fact I have different projects that use different stategies, and with this PR I want to add basic support into the core of this lib.

Currently it's not possible to request a new twitch app access token if someone use the non-twitch provider. Most apps, where i implemented a custom secret manager, or uses google/aws has already their own key rotation system. So there was no need to implement that right now.

This PR contains:

- Rewrite credentials management
- Drop php 7 support, since it's EOL
- Add amazon secret manager support
- Add google secret manager support
- Add documentaion on how to use the secret managers