### PR TITLE
Fix iCalendar wrong endpoint

### DIFF
--- a/src/Concerns/Api/ScheduleTrait.php
+++ b/src/Concerns/Api/ScheduleTrait.php
@@ -43,7 +43,7 @@ trait ScheduleTrait
     {
         $this->validateRequired($parameters, ['broadcaster_id']);
 
-        return $this->get('schedule', $parameters);
+        return $this->get('schedule/icalendar', $parameters);
     }
 
     /**


### PR DESCRIPTION
getChanneliCalendar had wrong get param. This updates it to work correctly and get the iCalendar data as expected