### PR TITLE
Adding Laravel 10 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "illuminate/cache": "^5.5|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/console": "^5.5|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/cache": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/console": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/support": "^5.5|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
v4.5.4 included commit 1679d493b0c1bae79f91b539ffd5dad01e6d859c to add Laravel 10 support, but composer.json was not updated to allow installing with Laravel 10.