### PR TITLE
Return Content-Type eq text/plain for WebHook verification

### DIFF
--- a/src/Http/Controllers/EventSubController.php
+++ b/src/Http/Controllers/EventSubController.php
@@ -66,7 +66,9 @@ class EventSubController extends Controller
      */
     protected function handleWebhookCallbackVerification(array $payload): Response
     {
-        return new Response($payload['challenge'], 200);
+        return new Response($payload['challenge'], 200, [
+            'Content-Type' => 'text/plain',
+        ]);
     }
 
     /**


### PR DESCRIPTION
I've tested the current implementation with the Twitch CLI. 

When running the webhook verification:
> twitch event verify-subscription subscribe -F http://localhost:8085/api/twitch/event-sub/webhook -s ${VERIFICATION_SECRET}

It resulted with an error:
> ✗ Invalid content-type header. Received type text/html with charset UTF-8. Expecting text/plain.