### PR TITLE
Fix createChannelStreamScheduleSegment to use $body correctly

### DIFF
--- a/src/Concerns/Api/ScheduleTrait.php
+++ b/src/Concerns/Api/ScheduleTrait.php
@@ -76,7 +76,9 @@ trait ScheduleTrait
     {
         $this->validateRequired($parameters, ['broadcaster_id']);
 
-        return $this->post('schedule/segment', $parameters);
+        $this->validateRequired($body, ['start_time', 'timezone', 'duration']);
+
+        return $this->post('schedule/segment', $parameters, null, $body);
     }
 
     /**


### PR DESCRIPTION
In the current version, createChannelStreamScheduleSegment does not use the $body property, and this endpoint requires it, with three required fields.

https://dev.twitch.tv/docs/api/reference/#create-channel-stream-schedule-segment see here for the missing required properties that I have added